### PR TITLE
migrate number input back to using event handlers instead of signals

### DIFF
--- a/dioxus-test-utils/src/signal.rs
+++ b/dioxus-test-utils/src/signal.rs
@@ -47,8 +47,10 @@ impl<T> TestSignalAccess<T> {
     ///
     /// If no signal has been linked to this access.
     pub fn set(&self, value: T, dom: &mut TestDom) {
-        let mut signal = self.0.signal.write().unwrap();
-        signal
+        self.0
+            .signal
+            .write()
+            .unwrap()
             .as_mut()
             .expect("test signal has not yet been linked")
             .set(value);

--- a/frontend/src/components/model_value_fields.rs
+++ b/frontend/src/components/model_value_fields.rs
@@ -10,16 +10,13 @@ use crate::components::number_input::NumberInput;
 
 #[component]
 pub fn RollInput(roll: Signal<Option<Roll>>) -> Element {
-    let roll_number = use_signal(|| roll().map(Roll::as_u8).unwrap_or(0));
-
-    use_effect(move || roll.set(Roll::new(roll_number())));
-
     rsx! {
         NumberInput::<u8> {
             class: "small-input",
             min: 0,
             max: 20,
-            value: roll_number,
+            value: roll().map(Roll::as_u8).unwrap_or(0),
+            on_change: move |value| roll.set(Roll::new(value)),
             zero_as_empty: true,
         }
     }
@@ -27,32 +24,26 @@ pub fn RollInput(roll: Signal<Option<Roll>>) -> Element {
 
 #[component]
 pub fn AttributeInput(attribute: Signal<skill::Attribute>) -> Element {
-    let attribute_number = use_signal(|| attribute().as_i32());
-
-    use_effect(move || attribute.set(skill::Attribute::new(attribute_number())));
-
     rsx! {
         NumberInput::<i32> {
             class: "small-input",
             min: 0,
             max: 20,
-            value: attribute_number,
+            value: attribute().as_i32(),
+            on_change: move |value| attribute.set(skill::Attribute::new(value)),
         }
     }
 }
 
 #[component]
 pub fn SkillPointsInput(skill_points: Signal<SkillPoints>) -> Element {
-    let skill_points_number = use_signal(|| skill_points().as_i32());
-
-    use_effect(move || skill_points.set(SkillPoints::new(skill_points_number())));
-
     rsx! {
         NumberInput::<i32> {
             class: "small-input",
             min: 0,
             max: 100,
-            value: skill_points_number,
+            value: skill_points().as_i32(),
+            on_change: move |value| skill_points.set(SkillPoints::new(value)),
         }
     }
 }
@@ -64,28 +55,21 @@ pub fn FatePointInput(fate_point_count: Signal<usize>) -> Element {
             class: "small-input",
             min: 0,
             max: 6,
-            value: fate_point_count,
+            value: fate_point_count(),
+            on_change: move |value| fate_point_count.set(value),
         }
     }
 }
 
 #[component]
 pub fn AptitudeInput(aptitude: Signal<Option<Aptitude>>) -> Element {
-    let aptitude_number = use_signal(|| {
-        aptitude()
-            .map(Aptitude::max_dice)
-            .map(NonZeroUsize::get)
-            .unwrap_or(0)
-    });
-
-    use_effect(move || aptitude.set(Aptitude::new(aptitude_number())));
-
     rsx! {
         NumberInput::<usize> {
             class: "small-input",
             min: 0,
             max: 2,
-            value: aptitude_number,
+            value: aptitude().map(Aptitude::max_dice).map(NonZeroUsize::get).unwrap_or(0),
+            on_change: move |value| aptitude.set(Aptitude::new(value)),
         }
     }
 }

--- a/frontend/src/components/number_input.rs
+++ b/frontend/src/components/number_input.rs
@@ -57,46 +57,19 @@ fn to_string<T: Int>(value: T, zero_as_empty: bool) -> String {
 
 #[component]
 pub fn NumberInput<T: Int>(
-    value: Signal<T>,
+    value: T,
+    on_change: EventHandler<T>,
     min: Option<T>,
     max: Option<T>,
     class: Option<String>,
     #[props(default = false)] zero_as_empty: bool,
 ) -> Element {
-    let mut text_value = use_signal(|| to_string(value(), zero_as_empty));
-
-    use_effect(move || {
-        let mut text_value = text_value();
-
-        if text_value.is_empty() {
-            text_value.push('0');
-        }
-
-        let parsed_value = match text_value.parse::<T>() {
-            Ok(parsed_value) => Some(parsed_value),
-            Err(err) if err.kind() == &IntErrorKind::PosOverflow => Some(T::MAX),
-            Err(err) if err.kind() == &IntErrorKind::NegOverflow => Some(T::MIN),
-            Err(err) if err.kind() == &IntErrorKind::InvalidDigit => {
-                let mut chars = text_value.chars();
-
-                if chars.next() == Some('-')
-                    && chars.next().is_some_and(|c| c.is_ascii_digit())
-                    && chars.all(|c| c.is_ascii_digit())
-                {
-                    // Negative overflow on unsigned integer ('-' is recognized as an invalid digit)
-                    Some(T::MIN)
-                }
-                else {
-                    None
-                }
-            },
-            _ => None,
-        };
-
-        if let Some(parsed_value) = parsed_value {
-            value.set(clamp(parsed_value, min, max));
-        }
-    });
+    // Normally input content is derived from `value`, but during editing this can lead to strange
+    // behavior, as the text is immediately updated to the model value. For example, attempting to
+    // enter "20" in a field with minimum 10 would immediately put a "10" into the field once the
+    // "2" is entered. To prevent this, the actual text value during editing is stored in this
+    // signal and cleared once editing ends (onblur).
+    let mut text_value = use_signal(|| None);
 
     rsx! {
         div {
@@ -111,14 +84,45 @@ pub fn NumberInput<T: Int>(
 
             input {
                 onblur: move |_| {
-                    text_value.set(to_string(value(), zero_as_empty));
+                    text_value.set(None);
                 },
 
                 oninput: move |event| {
-                    text_value.set(event.value());
+                    let mut value = event.value();
+
+                    text_value.set(Some(value.clone()));
+
+                    if value.is_empty() {
+                        value.push('0');
+                    }
+
+                    let parsed_value = match value.parse::<T>() {
+                        Ok(parsed_value) => Some(parsed_value),
+                        Err(err) if err.kind() == &IntErrorKind::PosOverflow => Some(T::MAX),
+                        Err(err) if err.kind() == &IntErrorKind::NegOverflow => Some(T::MIN),
+                        Err(err) if err.kind() == &IntErrorKind::InvalidDigit => {
+                            let mut chars = value.chars();
+
+                            if chars.next() == Some('-')
+                                && chars.next().is_some_and(|c| c.is_ascii_digit())
+                                && chars.all(|c| c.is_ascii_digit())
+                            {
+                                // Negative overflow on unsigned integer ('-' is recognized as an invalid digit)
+                                Some(T::MIN)
+                            }
+                            else {
+                                None
+                            }
+                        },
+                        _ => None,
+                    };
+
+                    if let Some(parsed_value) = parsed_value {
+                        on_change.call(clamp(parsed_value, min, max));
+                    }
                 },
 
-                value: text_value,
+                value: text_value().unwrap_or_else(|| to_string(value, zero_as_empty))
             }
 
             span {
@@ -126,21 +130,13 @@ pub fn NumberInput<T: Int>(
 
                 div {
                     button {
-                        onclick: move |_| {
-                            // Sets value in use_effect
-                            let new_value = clamp(value().saturating_inc(), min, max);
-                            text_value.set(to_string(new_value, zero_as_empty));
-                        },
+                        onclick: move |_| on_change.call(clamp(value.saturating_inc(), min, max)),
 
                         "⯅"
                     }
 
                     button {
-                        onclick: move |_| {
-                            // Sets value in use_effect
-                            let new_value = clamp(value().saturating_dec(), min, max);
-                            text_value.set(to_string(new_value, zero_as_empty));
-                        },
+                        onclick: move |_| on_change.call(clamp(value.saturating_dec(), min, max)),
 
                         "⯆"
                     }
@@ -152,7 +148,10 @@ pub fn NumberInput<T: Int>(
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Debug;
+
     use dioxus_test_utils::event::{
+        EventSender,
         EventType,
         FocusEventType,
         FormEventType,
@@ -160,7 +159,7 @@ mod tests {
         TestFormData,
     };
     use dioxus_test_utils::signal::TestSignal;
-    use dioxus_test_utils::{Find, NodeRefAssertions, TestDom};
+    use dioxus_test_utils::{Find, NodeRefAssertions, TestDom, event};
     use kernal::prelude::*;
     use rstest::rstest;
 
@@ -168,6 +167,7 @@ mod tests {
 
     fn mount_number_input<T: Int>(
         value: TestSignal<T>,
+        on_change: EventSender<T>,
         min: Option<T>,
         max: Option<T>,
         class: Option<String>,
@@ -176,14 +176,18 @@ mod tests {
         #[component]
         fn Wrapper<T: Int>(
             value: TestSignal<T>,
+            on_change: EventSender<T>,
             min: Option<T>,
             max: Option<T>,
             class: Option<String>,
             zero_as_empty: bool,
         ) -> Element {
+            let value = value.into_signal();
+
             rsx! {
                 NumberInput::<T> {
-                    value: value.into_signal(),
+                    value: value(),
+                    on_change: on_change.into_event_handler(),
                     min: min,
                     max: max,
                     class: class,
@@ -196,6 +200,7 @@ mod tests {
             Wrapper::<T>,
             WrapperProps {
                 value,
+                on_change,
                 min,
                 max,
                 class,
@@ -215,7 +220,8 @@ mod tests {
         #[case] expected_value: u8,
     ) {
         let (value_signal, value_access) = TestSignal::with_access(initial_value);
-        let mut dom = mount_number_input(value_signal, None, max, None, false);
+        let (on_changed, mut on_changed_receiver) = event::event_channel();
+        let mut dom = mount_number_input(value_signal, on_changed, None, max, None, false);
 
         assert_that!(dom.find("input")).has_attribute("value", format!("{}", initial_value));
 
@@ -223,21 +229,26 @@ mod tests {
             .at(dom.find_all("button")[0])
             .raise(&mut dom);
 
+        assert_that!(on_changed_receiver.try_next()).contains_value(Some(expected_value));
+
+        value_access.set(expected_value, &mut dom);
+
         assert_that!(dom.find("input")).has_attribute("value", format!("{}", expected_value));
-        assert_that!(value_access.get()).is_equal_to(expected_value);
     }
 
     #[rstest]
-    #[case::decrement_without_min(0, None, "-1")]
-    #[case::decrement_above_min(5, Some(4), "4")]
-    #[case::decrement_capped_by_min(-3, Some(-3), "-3")]
-    #[case::decrement_capped_by_min_of_type(i32::MIN, None, &i32::MIN.to_string())]
+    #[case::decrement_without_min(0, None, -1)]
+    #[case::decrement_above_min(5, Some(4), 4)]
+    #[case::decrement_capped_by_min(-3, Some(-3), -3)]
+    #[case::decrement_capped_by_min_of_type(i32::MIN, None, i32::MIN)]
     fn number_input_decrement_button(
         #[case] initial_value: i32,
         #[case] min: Option<i32>,
-        #[case] expected_value: &str,
+        #[case] expected_value: i32,
     ) {
-        let mut dom = mount_number_input(TestSignal::new(initial_value), min, None, None, false);
+        let (value_signal, value_access) = TestSignal::with_access(initial_value);
+        let (on_changed, mut on_changed_receiver) = event::event_channel();
+        let mut dom = mount_number_input(value_signal, on_changed, min, None, None, false);
 
         assert_that!(dom.find("input")).has_attribute("value", format!("{}", initial_value));
 
@@ -245,51 +256,89 @@ mod tests {
             .at(dom.find_all("button")[1])
             .raise(&mut dom);
 
-        assert_that!(dom.find("input")).has_attribute("value", expected_value);
+        assert_that!(on_changed_receiver.try_next()).contains_value(Some(expected_value));
+
+        value_access.set(expected_value, &mut dom);
+
+        assert_that!(dom.find("input")).has_attribute("value", format!("{}", expected_value));
     }
 
-    #[rstest]
-    #[case::empty(15, None, None, "", "0")]
-    #[case::entering_same_number(15, None, None, "15", "15")]
-    #[case::entering_invalid_number_1(15, None, None, "a", "15")]
-    #[case::entering_invalid_number_2(15, None, None, "-a", "15")]
-    #[case::entering_invalid_number_3(15, None, None, "-1a", "15")]
-    #[case::entering_invalid_number_4(15, None, None, "-", "15")]
-    #[case::without_bounds(0, None, None, "123", "123")]
-    #[case::within_bounds(0, Some(-100), Some(100), "-42", "-42")]
-    #[case::below_min(0, Some(-100), Some(100), "-123", "-100")]
-    #[case::above_max(0, Some(-100), Some(100), "123", "100")]
-    #[case::below_min_of_type_without_bounds(0, None, None, "-10000000000", &i32::MIN.to_string())]
-    #[case::above_max_of_type_without_bounds(0, None, None, "10000000000", &i32::MAX.to_string())]
-    #[case::below_min_of_unsigned_integer(1u8, None, None, "-1", "0")]
-    #[case::below_min_of_type_with_bounds(0, Some(-123), None, "-10000000000", "-123")]
-    #[case::above_max_of_type_with_bounds(0, None, Some(123), "10000000000", "123")]
-    fn number_input_text_input<T: Int>(
-        #[case] initial_value: T,
-        #[case] min: Option<T>,
-        #[case] max: Option<T>,
-        #[case] input: &str,
-        #[case] expected: &str,
-    ) {
-        let mut dom = mount_number_input(TestSignal::new(initial_value), min, max, None, false);
-
+    fn enter_text(dom: &mut TestDom, input: &str) {
         FormEventType::Input
             .at(dom.find("input"))
             .with(TestFormData {
                 value: input.to_owned(),
                 ..Default::default()
             })
-            .raise(&mut dom);
+            .raise(dom);
+    }
+
+    #[rstest]
+    #[case::empty(15, None, None, "", 0)]
+    #[case::entering_same_number(15, None, None, "15", 15)]
+    #[case::without_bounds(0, None, None, "123", 123)]
+    #[case::within_bounds(0, Some(-100), Some(100), "-42", -42)]
+    #[case::below_min(0, Some(-100), Some(100), "-123", -100)]
+    #[case::above_max(0, Some(-100), Some(100), "123", 100)]
+    #[case::below_min_of_type_without_bounds(0, None, None, "-10000000000", i32::MIN)]
+    #[case::above_max_of_type_without_bounds(0, None, None, "10000000000", i32::MAX)]
+    #[case::below_min_of_unsigned_integer(1u8, None, None, "-1", 0)]
+    #[case::below_min_of_type_with_bounds(0, Some(-123), None, "-10000000000", -123)]
+    #[case::above_max_of_type_with_bounds(0, None, Some(123), "10000000000", 123)]
+    fn number_input_text_input_ok<T: Debug + Int>(
+        #[case] initial_value: T,
+        #[case] min: Option<T>,
+        #[case] max: Option<T>,
+        #[case] input: &str,
+        #[case] expected_value: T,
+    ) {
+        let (value_signal, value_access) = TestSignal::with_access(initial_value);
+        let (on_changed, mut on_changed_receiver) = event::event_channel();
+        let mut dom = mount_number_input(value_signal, on_changed, min, max, None, false);
+
+        enter_text(&mut dom, input);
+
+        assert_that!(dom.find("input")).has_attribute("value", input);
+        assert_that!(on_changed_receiver.try_next()).contains_value(Some(expected_value));
+
+        value_access.set(expected_value, &mut dom);
         FocusEventType::Blur.at(dom.find("input")).raise(&mut dom);
 
-        assert_that!(dom.find("input")).has_attribute("value", expected);
+        assert_that!(dom.find("input")).has_attribute("value", format!("{}", expected_value));
+    }
+
+    #[rstest]
+    #[case("a")]
+    #[case("-a")]
+    #[case("-1a")]
+    #[case("-")]
+    fn number_input_text_input_error(#[case] input: &str) {
+        let (on_changed, mut on_changed_receiver) = event::event_channel();
+        let mut dom = mount_number_input(TestSignal::new(15), on_changed, None, None, None, false);
+
+        enter_text(&mut dom, input);
+
+        assert_that!(dom.find("input")).has_attribute("value", input);
+        assert_that!(on_changed_receiver.try_next()).is_err();
+
+        FocusEventType::Blur.at(dom.find("input")).raise(&mut dom);
+
+        assert_that!(dom.find("input")).has_attribute("value", "15");
     }
 
     #[rstest]
     #[case::yes(true, "")]
     #[case::no(false, "0")]
     fn number_input_zero_as_empty(#[case] zero_as_empty: bool, #[case] expected: &str) {
-        let dom = mount_number_input(TestSignal::new(0usize), None, None, None, zero_as_empty);
+        let (event_sender, _) = event::event_channel();
+        let dom = mount_number_input(
+            TestSignal::new(0usize),
+            event_sender,
+            None,
+            None,
+            None,
+            zero_as_empty,
+        );
         assert_that!(dom.find("input")).has_attribute("value", expected);
     }
 }


### PR DESCRIPTION
Motivation: Event Handlers give the using component the flexibility to use the event to change a part of its greater model without having to decompose it into smaller signals.